### PR TITLE
Allow empty LDFLAGS_benchmark in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -237,7 +237,7 @@ DEBUG=			$(rmdup ${DEBUG})
 AFLAGS=			$(rmdup ${AFLAGS})
 ASFLAGS=		$(rmdup ${ASFLAGS})
 LDFLAGS=		$(rmdup ${LDFLAGS})
-LDFLAGS_benchmark=	$(rmdup ${LDFLAGS_benchmark})
+LDFLAGS_benchmark=	$(rmdup ${LDFLAGS_benchmark:-})
 
 BINDIR?=		$(echo ${BINDIR})
 MANDIR?=		$(echo ${MANDIR})


### PR DESCRIPTION
At the point of writing the configuration to config.mk, `LDFLAGS_benchmark` is not set if `${_benchmark} != 1`.

Since this happens after:
```
# At this point, all variables used must be defined.
set -u
```
the configure script fails.
Attached is one way of solving this.